### PR TITLE
Feature/better mfdataset

### DIFF
--- a/pf_xarray/__init__.py
+++ b/pf_xarray/__init__.py
@@ -1,2 +1,2 @@
-from .pf_backend import ParflowBackendEntrypoint, ParflowAccessor, ParflowBackendArray
+from .pf_backend import ParflowBackendEntrypoint, ParflowBackendArray
 from .io import ParflowBinaryReader, read_pfb, read_stack_of_pfbs

--- a/pf_xarray/__init__.py
+++ b/pf_xarray/__init__.py
@@ -1,2 +1,2 @@
-from .pf_backend import ParflowBackendEntrypoint, ParflowAccessor, ParflowBackendArray, ParflowDataManager
+from .pf_backend import ParflowBackendEntrypoint, ParflowAccessor, ParflowBackendArray
 from .io import ParflowBinaryReader, read_pfb, read_stack_of_pfbs

--- a/pf_xarray/__init__.py
+++ b/pf_xarray/__init__.py
@@ -1,2 +1,2 @@
-from .pf_backend import ParflowBackendEntrypoint, ParflowAccessor, ParflowBackendArray, ParflowData
+from .pf_backend import ParflowBackendEntrypoint, ParflowAccessor, ParflowBackendArray, ParflowDataManager
 from .io import ParflowBinaryReader, read_pfb, read_stack_of_pfbs

--- a/pf_xarray/io.py
+++ b/pf_xarray/io.py
@@ -52,15 +52,17 @@ def read_stack_of_pfbs(file_seq: Iterable[str], keys=None):
         base_sg_locations = pfb_init.subgrid_locations
         base_sg_indices = pfb_init.subgrid_start_indices
         base_sg_shapes = pfb_init.subgrid_shapes
+        base_sg_chunks = pfb_init.chunks
+        base_sg_coords = pfb_init.coords
     if not keys:
         nx, ny, nz = base_header['nx'], base_header['ny'], base_header['nz']
     else:
         start_x = keys['x']['start']
         start_y = keys['y']['start']
         start_z = keys['z']['start']
-        nx = keys['x']['stop'] - start_x
-        ny = keys['y']['stop'] - keys['y']['start']
-        nz = keys['z']['stop'] - keys['z']['start']
+        nx = np.max([keys['x']['stop'] - start_x - 1, 1])
+        ny = np.max([keys['y']['stop'] - keys['y']['start'] - 1, 1])
+        nz = np.max([keys['z']['stop'] - keys['z']['start'] - 1, 1])
     stack_size = (len(file_seq), nx, ny, nz)
     pfb_stack = np.empty(stack_size, dtype=np.float64)
     for i, f in enumerate(file_seq):
@@ -71,6 +73,8 @@ def read_stack_of_pfbs(file_seq: Iterable[str], keys=None):
             pfb.subgrid_locations = base_sg_locations
             pfb.subgrid_start_indices = base_sg_indices
             pfb.subgrid_shapes = base_sg_shapes
+            pfb.coords = base_sg_coords
+            pfb.chunks = base_sg_chunks
             if not keys:
                 substack_data = pfb.read_all_subgrids(mode='full')
             else:

--- a/pf_xarray/pf_backend.py
+++ b/pf_xarray/pf_backend.py
@@ -215,6 +215,7 @@ class ParflowBackendEntrypoint(BackendEntrypoint):
             inf_shape = (len(all_files), *inf_shape)
             base_da = self.load_stack_of_pfb(
                     all_files, dims=inf_dims, shape=inf_shape)
+            base_da = xr.Dataset({'_': base_da})['_']
             #base_da = xr.open_mfdataset(
             #              all_files,
             #              engine='parflow',


### PR DESCRIPTION
This PR doesn't actually fix `xr.open_mfdataset` but it does make it much easier to load from `pfmetadata` files by reading stacks of `pfb` files very efficiently along the time dimension.